### PR TITLE
Add the missing chunk label `basebarfun_1` in Rcssplot.Rnw

### DIFF
--- a/vignettes/Rcssplot.Rnw
+++ b/vignettes/Rcssplot.Rnw
@@ -66,7 +66,7 @@ This vignette is organized as follows. The next section reviews how to create co
 
 To start, let's look at styling plots using R's built-in capabilities, called `base graphics'. For concreteness, let's use an example with a bar chart and a small data vector.
 
-<<>>=
+<<basebarfun_1>>=
 a <- setNames(c(35, 55, 65, 75, 80, 80), letters[1:6])
 a
 @


### PR DESCRIPTION
With the change https://github.com/yihui/knitr/commit/49f879398d87c12be4b7188e73f1c62c39167d79, invalid `<<>>` references will no longer be resolved. Previously, they were silently ignored. Now they will be left untouched, which will cause an error in this vignette at https://github.com/tkonopka/Rcssplot/blob/59688cd6c236dc5b6124ab04ea687297af0b4588/vignettes/Rcssplot.Rnw#L123